### PR TITLE
Add menu bar percentage controller and toggle

### DIFF
--- a/Battery Toolkit.xcodeproj/project.pbxproj
+++ b/Battery Toolkit.xcodeproj/project.pbxproj
@@ -38,12 +38,14 @@
 		CE50557228D65B48000E4387 /* BTXPCValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE50557028D65B48000E4387 /* BTXPCValidation.swift */; };
 		CE50557328D65C6D000E4387 /* BTPreprocessor.m in Sources */ = {isa = PBXBuildFile; fileRef = CEE387BD28A836AA00C2007C /* BTPreprocessor.m */; };
 		CE52867B28298B6E00860C7B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE52867A28298B6E00860C7B /* Assets.xcassets */; };
-		CE52868628298CA300860C7B /* BTAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE52868528298CA300860C7B /* BTAppDelegate.swift */; };
+                CE52868628298CA300860C7B /* BTAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE52868528298CA300860C7B /* BTAppDelegate.swift */; };
+                CEE65BAC2FCF4DD1877D1FC2 /* BTBatteryStatusItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568C1F98673F42BF83B2D255 /* BTBatteryStatusItemController.swift */; };
 		CE54510228D9FE9D00D6EB5F /* BTDaemonManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE54510128D9FE9D00D6EB5F /* BTDaemonManagement.swift */; };
 		CE54510428DA017300D6EB5F /* BTAppPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE54510328DA017300D6EB5F /* BTAppPrompts.swift */; };
 		CE5E5AE328DE214200AF1D07 /* BTAccessoryMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E5AE228DE214200AF1D07 /* BTAccessoryMode.swift */; };
 		CE5E5AE528DE292D00AF1D07 /* BTCommandsMenuDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E5AE428DE292D00AF1D07 /* BTCommandsMenuDelegate.swift */; };
-		CE5E5AE828DE31EB00AF1D07 /* BTSettingsMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E5AE728DE31EB00AF1D07 /* BTSettingsMenuItem.swift */; };
+                CE5E5AE828DE31EB00AF1D07 /* BTSettingsMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E5AE728DE31EB00AF1D07 /* BTSettingsMenuItem.swift */; };
+                C4B7E3A33A1F4411B1F3CF84 /* BTAppPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E749EA9022D4EC492904245 /* BTAppPreferences.swift */; };
 		CE5E5AF328DF183E00AF1D07 /* BTAuthorizationRights.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E5AF228DF183E00AF1D07 /* BTAuthorizationRights.swift */; };
 		CE5E5AF428DF183E00AF1D07 /* BTAuthorizationRights.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E5AF228DF183E00AF1D07 /* BTAuthorizationRights.swift */; };
 		CE5E5AF628DF187C00AF1D07 /* BTAuthorizationRights.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E5AF228DF183E00AF1D07 /* BTAuthorizationRights.swift */; };
@@ -196,12 +198,14 @@
 		CE50557028D65B48000E4387 /* BTXPCValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTXPCValidation.swift; sourceTree = "<group>"; };
 		CE52867A28298B6E00860C7B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CE52867F28298B6E00860C7B /* BatteryToolkit.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BatteryToolkit.entitlements; sourceTree = "<group>"; };
-		CE52868528298CA300860C7B /* BTAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAppDelegate.swift; sourceTree = "<group>"; };
+                CE52868528298CA300860C7B /* BTAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAppDelegate.swift; sourceTree = "<group>"; };
+                568C1F98673F42BF83B2D255 /* BTBatteryStatusItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTBatteryStatusItemController.swift; sourceTree = "<group>"; };
 		CE54510128D9FE9D00D6EB5F /* BTDaemonManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTDaemonManagement.swift; sourceTree = "<group>"; };
 		CE54510328DA017300D6EB5F /* BTAppPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAppPrompts.swift; sourceTree = "<group>"; };
 		CE5E5AE228DE214200AF1D07 /* BTAccessoryMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAccessoryMode.swift; sourceTree = "<group>"; };
 		CE5E5AE428DE292D00AF1D07 /* BTCommandsMenuDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTCommandsMenuDelegate.swift; sourceTree = "<group>"; };
-		CE5E5AE728DE31EB00AF1D07 /* BTSettingsMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSettingsMenuItem.swift; sourceTree = "<group>"; };
+                CE5E5AE728DE31EB00AF1D07 /* BTSettingsMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTSettingsMenuItem.swift; sourceTree = "<group>"; };
+                7E749EA9022D4EC492904245 /* BTAppPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAppPreferences.swift; sourceTree = "<group>"; };
 		CE5E5AF228DF183E00AF1D07 /* BTAuthorizationRights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTAuthorizationRights.swift; sourceTree = "<group>"; };
 		CE5E5AF728DF1CB100AF1D07 /* BTError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTError.swift; sourceTree = "<group>"; };
 		CE675D9528C7E81600F05929 /* me.mhaeuser.batterytoolkitd.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = me.mhaeuser.batterytoolkitd.plist; sourceTree = "<group>"; };
@@ -380,20 +384,21 @@
 			path = Libraries;
 			sourceTree = "<group>";
 		};
-		CE6B75F728BC18DD008DF170 /* Common */ = {
-			isa = PBXGroup;
-			children = (
-				CE5E5AF228DF183E00AF1D07 /* BTAuthorizationRights.swift */,
-				CEA80FDA285A57030064ADEA /* BTDaemonCommProtocol.swift */,
-				CE5E5AF728DF1CB100AF1D07 /* BTError.swift */,
-				CE3C1DA628CA33FD008A0F7D /* BTLegacyHelperInfo.swift */,
-				CE0DB56228BEB4E600B8FC4C /* BTSettingsInfo.swift */,
-				CEB4A42728D3B184004FA277 /* BTStateInfo.swift */,
-				CE50557028D65B48000E4387 /* BTXPCValidation.swift */,
-			);
-			path = Common;
-			sourceTree = "<group>";
-		};
+                CE6B75F728BC18DD008DF170 /* Common */ = {
+                        isa = PBXGroup;
+                        children = (
+                                CE5E5AF228DF183E00AF1D07 /* BTAuthorizationRights.swift */,
+                                CEA80FDA285A57030064ADEA /* BTDaemonCommProtocol.swift */,
+                                CE5E5AF728DF1CB100AF1D07 /* BTError.swift */,
+                                CE3C1DA628CA33FD008A0F7D /* BTLegacyHelperInfo.swift */,
+                                CE0DB56228BEB4E600B8FC4C /* BTSettingsInfo.swift */,
+                                CEB4A42728D3B184004FA277 /* BTStateInfo.swift */,
+                                CE50557028D65B48000E4387 /* BTXPCValidation.swift */,
+                                7E749EA9022D4EC492904245 /* BTAppPreferences.swift */,
+                        );
+                        path = Common;
+                        sourceTree = "<group>";
+                };
 		CE6C06A328A84A9200D76CC8 /* IOPMPrivate */ = {
 			isa = PBXGroup;
 			children = (
@@ -465,16 +470,17 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
-		CEA3908A28DF95490023261A /* Main */ = {
-			isa = PBXGroup;
-			children = (
-				CE37DD0A283F80960060C43F /* Main.storyboard */,
-				CE52868528298CA300860C7B /* BTAppDelegate.swift */,
-				CE5E5AE428DE292D00AF1D07 /* BTCommandsMenuDelegate.swift */,
-			);
-			path = Main;
-			sourceTree = "<group>";
-		};
+                CEA3908A28DF95490023261A /* Main */ = {
+                        isa = PBXGroup;
+                        children = (
+                                CE37DD0A283F80960060C43F /* Main.storyboard */,
+                                CE52868528298CA300860C7B /* BTAppDelegate.swift */,
+                                568C1F98673F42BF83B2D255 /* BTBatteryStatusItemController.swift */,
+                                CE5E5AE428DE292D00AF1D07 /* BTCommandsMenuDelegate.swift */,
+                        );
+                        path = Main;
+                        sourceTree = "<group>";
+                };
 		CEB4671C2843C80D00D7CB01 /* SMCParamStruct */ = {
 			isa = PBXGroup;
 			children = (
@@ -735,17 +741,19 @@
 				CEB4A42F28D4D4D0004FA277 /* BTSettingsWindowController.swift in Sources */,
 				CE397478285A25A1002D0EC9 /* BTDaemonXPCClient.swift in Sources */,
 				CE5E5AF828DF1CB100AF1D07 /* BTError.swift in Sources */,
-				CE0DB56328BEB4E600B8FC4C /* BTSettingsInfo.swift in Sources */,
-				CE5E5AF328DF183E00AF1D07 /* BTAuthorizationRights.swift in Sources */,
+                                CE0DB56328BEB4E600B8FC4C /* BTSettingsInfo.swift in Sources */,
+                                C4B7E3A33A1F4411B1F3CF84 /* BTAppPreferences.swift in Sources */,
+                                CE5E5AF328DF183E00AF1D07 /* BTAuthorizationRights.swift in Sources */,
 				CE30CBA128C48995001E2AC6 /* BTSettingsViewController.swift in Sources */,
 				CE5E5AE528DE292D00AF1D07 /* BTCommandsMenuDelegate.swift in Sources */,
 				CE85D05F28D7B7E6005D1E0C /* BTDaemonManagement+Service.swift in Sources */,
 				CEA3909328DFAE1C0023261A /* BTXPCValidation.swift in Sources */,
 				CEECE33028BB742500821A3B /* BTServiceCommProtocol.swift in Sources */,
 				CE3179ED28DB543600E9C121 /* SimpleAuth.swift in Sources */,
-				CE39746E285A229F002D0EC9 /* BTActions.swift in Sources */,
-				CE52868628298CA300860C7B /* BTAppDelegate.swift in Sources */,
-				CE1F5E3C28D760D400F61F67 /* BTLocalization.swift in Sources */,
+                                CE39746E285A229F002D0EC9 /* BTActions.swift in Sources */,
+                                CE52868628298CA300860C7B /* BTAppDelegate.swift in Sources */,
+                                CEE65BAC2FCF4DD1877D1FC2 /* BTBatteryStatusItemController.swift in Sources */,
+                                CE1F5E3C28D760D400F61F67 /* BTLocalization.swift in Sources */,
 				CE3C1DA728CA33FD008A0F7D /* BTLegacyHelperInfo.swift in Sources */,
 				CE2322D428E5EB8B00874CDE /* BTLoginItem.swift in Sources */,
 				CEB4A42828D3B184004FA277 /* BTStateInfo.swift in Sources */,

--- a/BatteryToolkit/Views/Main/BTAppDelegate.swift
+++ b/BatteryToolkit/Views/Main/BTAppDelegate.swift
@@ -9,7 +9,8 @@ import os.log
 @main
 @MainActor
 internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
-    private var menuBarExtraItem: NSStatusItem?
+    private var menuBarStatusItemController: BTBatteryStatusItemController?
+    private var showMenuBarPercentageObserver: NSObjectProtocol?
     @IBOutlet private var menuBarExtraMenu: NSMenu!
 
     @IBOutlet private var settingsItem: NSMenuItem!
@@ -24,6 +25,8 @@ internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_: Notification) {
+        self.teardownMenuBarStatusItem()
+
         Task { @BTBackgroundActor in
             BTActions.stop()
         }
@@ -31,10 +34,10 @@ internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillBecomeActive(_: Notification) {
         //
-        // Use the menuBarExtraItem value as an indicator for whether the app
+        // Use the menuBarStatusItemController value as an indicator for whether the app
         // has fully initialized.
         //
-        guard self.menuBarExtraItem != nil else {
+        guard self.menuBarStatusItemController != nil else {
             return
         }
 
@@ -42,7 +45,7 @@ internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillResignActive(_: Notification) {
-        guard self.menuBarExtraItem != nil else {
+        guard self.menuBarStatusItemController != nil else {
             return
         }
 
@@ -60,6 +63,8 @@ internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
         case .notRegistered:
             os_log("Daemon not registered")
 
+            self.teardownMenuBarStatusItem()
+
             if BTAppPrompts.promptRegisterDaemonError() {
                 let status = await BTActions.startDaemon()
                 await self.daemonStatusHandler(status: status)
@@ -73,30 +78,35 @@ internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
                 self.disableBackgroundItem.isEnabled = true
                 self.settingsItem.isEnabled = true
                 self.commandsMenuItem.isHidden = false
-                
-                let image = NSImage(
-                    named: NSImage.Name("ExtraItemIcon")
+
+                if self.menuBarStatusItemController == nil {
+                    self.menuBarStatusItemController = BTBatteryStatusItemController(
+                        menu: self.menuBarExtraMenu
+                    )
+                }
+
+                self.installMenuBarPercentageObserver()
+
+                let showPercentage = UserDefaults.standard.bool(
+                    forKey: BTAppPreferences.Keys.showMenuBarPercentage
                 )
-                image?.isTemplate = true
-                
-                let extraItem = NSStatusBar.system.statusItem(
-                    withLength: NSStatusItem.squareLength
-                )
-                extraItem.button?.image = image
-                extraItem.menu = self.menuBarExtraMenu
-                self.menuBarExtraItem = extraItem
-                
+                self.menuBarStatusItemController?.setShowsPercentage(showPercentage)
+
                 if !NSApp.isActive {
                     BTAccessoryMode.activate()
                 }
             } catch BTError.unsupported {
+                self.teardownMenuBarStatusItem()
                 await BTAppPrompts.promptMachineUnsupported()
             } catch {
+                self.teardownMenuBarStatusItem()
                 BTErrorHandler.errorHandler(error: error)
             }
 
         case .requiresApproval:
             os_log("Daemon requires approval")
+
+            self.teardownMenuBarStatusItem()
 
             do {
                 try await BTAppPrompts.promptApproveDaemon(timeout: 20)
@@ -107,6 +117,8 @@ internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
 
         case .requiresUpgrade:
             os_log("Daemon requires upgrade")
+
+            self.teardownMenuBarStatusItem()
 
             let storyboard = NSStoryboard(
                 name: "Upgrading",
@@ -121,5 +133,44 @@ internal final class BTAppDelegate: NSObject, NSApplicationDelegate {
             upgradingController.close()
             await self.daemonStatusHandler(status: status)
         }
+    }
+
+    private func installMenuBarPercentageObserver() {
+        guard self.showMenuBarPercentageObserver == nil else {
+            return
+        }
+
+        self.showMenuBarPercentageObserver = NotificationCenter.default.addObserver(
+            forName: .btShowMenuBarPercentageChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else {
+                return
+            }
+
+            let storedValue = UserDefaults.standard.bool(
+                forKey: BTAppPreferences.Keys.showMenuBarPercentage
+            )
+
+            guard let valueNumber = notification.userInfo?[
+                BTAppPreferences.NotificationUserInfoKey.value
+            ] as? NSNumber else {
+                self.menuBarStatusItemController?.setShowsPercentage(storedValue)
+                return
+            }
+
+            self.menuBarStatusItemController?.setShowsPercentage(valueNumber.boolValue)
+        }
+    }
+
+    private func teardownMenuBarStatusItem() {
+        if let observer = self.showMenuBarPercentageObserver {
+            NotificationCenter.default.removeObserver(observer)
+            self.showMenuBarPercentageObserver = nil
+        }
+
+        self.menuBarStatusItemController?.stop()
+        self.menuBarStatusItemController = nil
     }
 }

--- a/BatteryToolkit/Views/Main/BTBatteryStatusItemController.swift
+++ b/BatteryToolkit/Views/Main/BTBatteryStatusItemController.swift
@@ -1,0 +1,114 @@
+//
+// Copyright (C) 2024 Marvin Häuser. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Cocoa
+import notify
+import os.log
+
+@MainActor
+internal final class BTBatteryStatusItemController {
+    private let statusItem: NSStatusItem
+    private let templateImage: NSImage?
+
+    private var notifyToken: Int32? = nil
+    private var showsPercentage = false
+    private var isStopped = false
+
+    init(menu: NSMenu) {
+        self.statusItem = NSStatusBar.system.statusItem(
+            withLength: NSStatusItem.variableLength
+        )
+        self.statusItem.menu = menu
+        self.statusItem.button?.alignment = .center
+
+        let image = NSImage(named: NSImage.Name("ExtraItemIcon"))
+        image?.isTemplate = true
+        self.templateImage = image
+
+        self.applyTemplateImage()
+    }
+
+    deinit {
+        self.stop()
+    }
+
+    func setShowsPercentage(_ showsPercentage: Bool) {
+        guard !self.isStopped else {
+            return
+        }
+
+        self.showsPercentage = showsPercentage
+
+        if showsPercentage {
+            self.startPercentNotifications()
+        } else {
+            self.stopPercentNotifications()
+            self.applyTemplateImage()
+        }
+    }
+
+    func stop() {
+        guard !self.isStopped else {
+            return
+        }
+
+        self.stopPercentNotifications()
+        NSStatusBar.system.removeStatusItem(self.statusItem)
+        self.isStopped = true
+    }
+
+    private func startPercentNotifications() {
+        self.refreshPercentDisplay()
+
+        guard self.notifyToken == nil else {
+            return
+        }
+
+        var token: Int32 = 0
+        let status = notify_register_dispatch(
+            IOPSPrivate.kIOPSNotifyPercentChange,
+            &token,
+            DispatchQueue.main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshPercentDisplay()
+            }
+        }
+        guard status == NOTIFY_STATUS_OK else {
+            os_log("Failed to register percent change notification - \(status)")
+            return
+        }
+
+        self.notifyToken = token
+    }
+
+    private func stopPercentNotifications() {
+        if let token = self.notifyToken {
+            notify_cancel(token)
+            self.notifyToken = nil
+        }
+    }
+
+    private func refreshPercentDisplay() {
+        guard self.showsPercentage else {
+            return
+        }
+
+        guard let (percent, _, _) = IOPSPrivate.GetPercentRemaining() else {
+            self.applyTemplateImage()
+            return
+        }
+
+        self.statusItem.button?.image = nil
+        self.statusItem.button?.imagePosition = .noImage
+        self.statusItem.button?.title = String(format: "%d%%", Int(percent))
+    }
+
+    private func applyTemplateImage() {
+        self.statusItem.button?.title = ""
+        self.statusItem.button?.image = self.templateImage
+        self.statusItem.button?.imagePosition = .imageOnly
+    }
+}

--- a/BatteryToolkit/Views/Settings/BTSettingsViewController.swift
+++ b/BatteryToolkit/Views/Settings/BTSettingsViewController.swift
@@ -9,6 +9,7 @@ import os.log
 @MainActor
 internal final class BTSettingsViewController: NSViewController {
     private let autostartSetting = "autostart"
+    private let showMenuBarPercentageSetting = BTAppPreferences.Keys.showMenuBarPercentage
     
     private var currentSettings: [String: NSObject & Sendable]? = nil
     
@@ -17,6 +18,7 @@ internal final class BTSettingsViewController: NSViewController {
     @IBOutlet private var powerTab: NSTabViewItem!
     
     @IBOutlet private var autostartSwitch: NSSwitch!
+    @IBOutlet private var showMenuBarPercentageSwitch: NSSwitch!
     
     @IBOutlet private var minChargeTextField: NSTextField!
     @IBOutlet private var minChargeSlider: NSSlider!
@@ -165,6 +167,25 @@ internal final class BTSettingsViewController: NSViewController {
             }
         }
     }
+
+    @IBAction private func showMenuBarPercentageSwitchChanged(_ sender: NSSwitch) {
+        let showPercentage = (sender.state == .on)
+
+        UserDefaults.standard.set(
+            showPercentage,
+            forKey: self.showMenuBarPercentageSetting
+        )
+
+        NotificationCenter.default.post(
+            name: .btShowMenuBarPercentageChanged,
+            object: nil,
+            userInfo: [
+                BTAppPreferences.NotificationUserInfoKey.value: NSNumber(
+                    value: showPercentage
+                ),
+            ]
+        )
+    }
     
     override func viewWillAppear() {
         super.viewWillAppear()
@@ -211,6 +232,11 @@ internal final class BTSettingsViewController: NSViewController {
             forKey: self.autostartSetting
         )
         self.autostartSwitch.state = autostart ? .on : .off
+
+        let showPercentage = UserDefaults.standard.bool(
+            forKey: self.showMenuBarPercentageSetting
+        )
+        self.showMenuBarPercentageSwitch.state = showPercentage ? .on : .off
     }
     
     private func initPowerState() async {

--- a/BatteryToolkit/Views/Settings/Base.lproj/Settings.storyboard
+++ b/BatteryToolkit/Views/Settings/Base.lproj/Settings.storyboard
@@ -310,11 +310,11 @@
                                     </tabViewItem>
                                     <tabViewItem label="User" identifier="" id="r6x-U7-0zu" userLabel="User">
                                         <view key="view" id="j3z-8d-YbE">
-                                            <rect key="frame" x="0.0" y="0.0" width="495" height="107"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="495" height="180"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WLE-5m-DuI" userLabel="Autostart Label">
-                                                    <rect key="frame" x="18" y="71" width="415" height="16"/>
+                                                    <rect key="frame" x="18" y="144" width="415" height="16"/>
                                                     <textFieldCell key="cell" lineBreakMode="clipping" title="Open Battery Toolkit automatically when you log in to your Mac" id="23Z-ec-mgU">
                                                         <font key="font" usesAppearanceFont="YES"/>
                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -322,7 +322,7 @@
                                                     </textFieldCell>
                                                 </textField>
                                                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cMq-jp-fNI" userLabel="Autostart Secondary Label">
-                                                    <rect key="frame" x="18" y="20" width="415" height="48"/>
+                                                    <rect key="frame" x="18" y="93" width="415" height="48"/>
                                                     <textFieldCell key="cell" selectable="YES" id="5XS-zv-zfd">
                                                         <font key="font" metaFont="system"/>
                                                         <string key="title">Display a menu bar extra to easily control the power state of your Mac. The background activity is independent from the application and is unaffected by this setting.</string>
@@ -330,8 +330,31 @@
                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aoN-7d-qLf" userLabel="Menu Bar Percentage Label">
+                                                    <rect key="frame" x="18" y="57" width="415" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" title="Show the battery percentage in the menu bar" id="mLb-8X-1qP">
+                                                        <font key="font" usesAppearanceFont="YES"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="hL3-xr-YmP" userLabel="Menu Bar Percentage Secondary Label">
+                                                    <rect key="frame" x="18" y="20" width="415" height="34"/>
+                                                    <textFieldCell key="cell" selectable="YES" id="9h4-mk-mDg">
+                                                        <font key="font" metaFont="system"/>
+                                                        <string key="title">Display the remaining charge next to the Battery Toolkit icon when enabled.</string>
+                                                        <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
                                                 <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" controlSize="mini" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="Wvm-DK-CLx">
-                                                    <rect key="frame" x="448" y="70" width="28" height="17"/>
+                                                    <rect key="frame" x="448" y="143" width="28" height="17"/>
+                                                </switch>
+                                                <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" controlSize="mini" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="X3g-Yu-zsL" userLabel="Show Percentage Switch">
+                                                    <rect key="frame" x="448" y="57" width="28" height="17"/>
+                                                    <connections>
+                                                        <action selector="showMenuBarPercentageSwitchChanged:" target="qK6-EM-YZH" id="yPe-0F-wXi"/>
+                                                    </connections>
                                                 </switch>
                                             </subviews>
                                             <constraints>
@@ -340,12 +363,21 @@
                                                 <constraint firstItem="cMq-jp-fNI" firstAttribute="width" secondItem="WLE-5m-DuI" secondAttribute="width" id="OvW-Z0-w88"/>
                                                 <constraint firstItem="WLE-5m-DuI" firstAttribute="leading" secondItem="j3z-8d-YbE" secondAttribute="leading" constant="20" symbolic="YES" id="QsY-z4-Z1J"/>
                                                 <constraint firstItem="cMq-jp-fNI" firstAttribute="top" secondItem="WLE-5m-DuI" secondAttribute="bottom" constant="3" id="RLJ-WU-wkn"/>
-                                                <constraint firstAttribute="bottom" secondItem="cMq-jp-fNI" secondAttribute="bottom" constant="20" symbolic="YES" id="SpW-aD-EEi"/>
                                                 <constraint firstItem="Wvm-DK-CLx" firstAttribute="centerY" secondItem="WLE-5m-DuI" secondAttribute="centerY" id="X2r-vp-eIG"/>
                                                 <constraint firstItem="WLE-5m-DuI" firstAttribute="top" secondItem="j3z-8d-YbE" secondAttribute="top" constant="20" symbolic="YES" id="ik4-AR-JeR"/>
                                                 <constraint firstAttribute="trailing" secondItem="Wvm-DK-CLx" secondAttribute="trailing" constant="20" symbolic="YES" id="is0-kH-dIf"/>
                                                 <constraint firstItem="Wvm-DK-CLx" firstAttribute="top" secondItem="j3z-8d-YbE" secondAttribute="top" constant="20" symbolic="YES" id="q46-Mu-zAe"/>
                                                 <constraint firstItem="Wvm-DK-CLx" firstAttribute="leading" secondItem="WLE-5m-DuI" secondAttribute="trailing" constant="18" id="qfh-XJ-WgY"/>
+                                                <constraint firstItem="aoN-7d-qLf" firstAttribute="leading" secondItem="j3z-8d-YbE" secondAttribute="leading" constant="20" symbolic="YES" id="g3F-8X-QxC"/>
+                                                <constraint firstItem="aoN-7d-qLf" firstAttribute="width" secondItem="WLE-5m-DuI" secondAttribute="width" id="mMO-4C-qew"/>
+                                                <constraint firstItem="aoN-7d-qLf" firstAttribute="top" secondItem="cMq-jp-fNI" secondAttribute="bottom" constant="-20" id="ZxQ-80-37E"/>
+                                                <constraint firstItem="X3g-Yu-zsL" firstAttribute="leading" secondItem="aoN-7d-qLf" secondAttribute="trailing" constant="18" id="VZx-4h-n09"/>
+                                                <constraint firstItem="X3g-Yu-zsL" firstAttribute="centerY" secondItem="aoN-7d-qLf" secondAttribute="centerY" id="P4P-fN-ZqN"/>
+                                                <constraint firstAttribute="trailing" secondItem="X3g-Yu-zsL" secondAttribute="trailing" constant="20" symbolic="YES" id="dUA-Di-FoO"/>
+                                                <constraint firstItem="hL3-xr-YmP" firstAttribute="leading" secondItem="aoN-7d-qLf" secondAttribute="leading" id="tQo-nC-Bi4"/>
+                                                <constraint firstItem="hL3-xr-YmP" firstAttribute="width" secondItem="aoN-7d-qLf" secondAttribute="width" id="dRy-4L-yqf"/>
+                                                <constraint firstItem="hL3-xr-YmP" firstAttribute="top" secondItem="aoN-7d-qLf" secondAttribute="bottom" constant="-3" id="rte-6w-d2p"/>
+                                                <constraint firstAttribute="bottom" secondItem="hL3-xr-YmP" secondAttribute="bottom" constant="20" symbolic="YES" id="GuR-Yc-k9g"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
@@ -405,6 +437,7 @@ Gw
                     <connections>
                         <outlet property="adapterSleepSwitch" destination="ueg-wa-VAZ" id="3Lx-ht-YnK"/>
                         <outlet property="autostartSwitch" destination="Wvm-DK-CLx" id="76Y-hQ-vd0"/>
+                        <outlet property="showMenuBarPercentageSwitch" destination="X3g-Yu-zsL" id="wDk-0d-JlQ"/>
                         <outlet property="magSafeSyncSwitch" destination="Sq5-KE-c3T" id="csD-RV-ou4"/>
                         <outlet property="powerTab" destination="IMi-pw-cwy" id="9fR-1S-DaG"/>
                         <outlet property="tabView" destination="NXG-fh-uCo" id="DNX-YP-mN9"/>

--- a/Common/BTAppPreferences.swift
+++ b/Common/BTAppPreferences.swift
@@ -1,0 +1,22 @@
+//
+// Copyright (C) 2024 Marvin Häuser. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Foundation
+
+enum BTAppPreferences {
+    enum Keys {
+        static let showMenuBarPercentage = "showMenuBarPercentage"
+    }
+
+    enum NotificationUserInfoKey {
+        static let value = "value"
+    }
+}
+
+extension Notification.Name {
+    static let btShowMenuBarPercentageChanged = Notification.Name(
+        "BTShowMenuBarPercentageChanged"
+    )
+}


### PR DESCRIPTION
## Summary
- add a MainActor `BTBatteryStatusItemController` that owns the status item and percent notification lifecycle
- update the app delegate to use the controller, react to percentage preference changes, and clean up observers on shutdown
- expose a user preference and settings toggle to control showing the battery percentage in the menu bar

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6545ba5a4832ab085040e235c7e72